### PR TITLE
Feature/Alatau City Bank pdf parser 

### DIFF
--- a/parsers/__init__.py
+++ b/parsers/__init__.py
@@ -1,4 +1,4 @@
 from .otbasy import OtbasyParser
 from .halyk import HalykParser
-
-__all__ = ['OtbasyParser', 'HalykParser']
+from .alataucity import AlatauCityParser
+__all__ = ['OtbasyParser', 'HalykParser', 'AlatauCityParser']

--- a/parsers/alataucity.py
+++ b/parsers/alataucity.py
@@ -1,0 +1,119 @@
+import pdfplumber
+import io
+import re
+
+from .base import Parser
+from ..models import Payment, ParseError, ParseResult
+
+
+class AlatauCityParser(Parser):
+    def can_parse(self, file_bytes: bytes) -> bool:
+        #проверка  на принадлежность к Alatau City
+        try:
+            with pdfplumber.open(io.BytesIO(file_bytes)) as pdf:
+                if len(pdf.pages) == 0:
+                    return False
+
+                first_page_text = pdf.pages[0].extract_text()
+                if not first_page_text:
+                    return False
+
+                text_lower = first_page_text.lower()
+                # Ищем упоминание банка и слово "выписка"
+                has_bank = 'alatau city bank' in text_lower
+                has_statement = 'выписка' in text_lower
+
+                return has_bank and has_statement
+        except:
+            return False
+
+    def parse(self, file_bytes: bytes) -> ParseResult:
+        result = ParseResult()
+
+        # таблица с линиями
+        # используем настройки извлечения по сетке
+        table_settings = {
+            "vertical_strategy": "lines",
+            "horizontal_strategy": "lines",
+        }
+
+        try:
+            with pdfplumber.open(io.BytesIO(file_bytes)) as pdf:
+                for page_num, page in enumerate(pdf.pages):
+
+                    # Извлекаем все таблицы на странице
+                    tables = page.extract_tables(table_settings)
+
+                    for table in tables:
+                        for row_idx, row in enumerate(table):
+                            # Очищаем ячейки от пустых значений (None)
+                            clean_row = [str(cell).strip() if cell else "" for cell in row]
+
+                            # В таблице Alatau City Bank 13 колонок + Защита от коротких/пустых строк
+                            if len(clean_row) < 12:
+                                continue
+
+                            # Пропускаем шапку таблицы (если в первой колонке слово "Дата")
+                            if 'дата' in clean_row[0].lower() or 'итого' in clean_row[0].lower():
+                                continue
+
+                            try:
+                                # Дата идет с временем , берем только первую часть
+                                date_raw = clean_row[0].split('\n')[0].strip()
+
+                                #прoвоерка. Если дата не похожа на ДД.ММ.ГГГГ, это не строка с транзакцией
+                                if not re.match(r'\d{2}\.\d{2}\.\d{4}', date_raw):
+                                    continue
+
+                                # Заменяем опечатки 'О' на '0' перед парсингом сумм
+                                debit_raw = clean_row[3].replace('О', '0').replace('O', '0')
+                                credit_raw = clean_row[4].replace('О', '0').replace('O', '0')
+
+                                merchant_desc = clean_row[8].replace('\n', ' ').strip()
+                                correspondent = clean_row[9].replace('\n', ' ').strip()
+                                iin_bin_str = clean_row[10].replace('\n', ' ').strip()
+
+
+                                debit = float(self.clean_amount(debit_raw))
+                                credit = float(self.clean_amount(credit_raw))
+
+                                amount = 0.0
+                                t_type = ""
+
+
+                                if debit > 0:
+                                    amount = debit
+                                    t_type = "expense"
+                                elif credit > 0:
+                                    amount = credit
+                                    t_type = "income"
+                                else:
+                                    continue  # Пропускаем строки с нулевыми оборотами
+
+                                # Склеиваем корреспондента и назначение платежа в поле merchant
+                                merchant_text = f"{correspondent} | {merchant_desc}".strip(" |")
+
+                                payment = Payment(
+                                    date=date_raw,
+                                    amount=amount,
+                                    currency="KZT",
+                                    type=t_type,
+                                    merchant=merchant_text,
+                                    bank="Alatau City Bank",
+                                    correspondent=correspondent,
+                                    iin_bin=iin_bin_str
+                                )
+                                result.payments.append(payment)
+
+                            except Exception as e:
+                                result.errors.append(ParseError(
+                                    row=row_idx,
+                                    column=-1,
+                                    message=f"Страница {page_num + 1}. Ошибка парсинга: {e}",
+                                    rawValue=str(clean_row)
+                                ))
+
+        except Exception as e:
+            result.errors.append(ParseError(row=0, column=0, message=f"Критическая ошибка: {e}", rawValue=""))
+
+        return result

--- a/processor.py
+++ b/processor.py
@@ -4,13 +4,14 @@ from .models import ParseResult, ParseError
 from .parsers.base import Parser
 from .parsers.otbasy import OtbasyParser
 from .parsers.halyk import HalykParser
-
+from .parsers.alataucity import AlatauCityParser
 class StatementProcessor:
     def __init__(self):
         # Теперь оба парсера - это классы, наследуемые от Parser
         self.parsers: List[Parser] = [
             OtbasyParser(),
             HalykParser(),
+            AlatauCityParser(),
         ]
 
     def process_file(self, file_path: str) -> ParseResult:


### PR DESCRIPTION
**Что сделано**
- Создан новый класс AlatauCityParser в файле parsers/alatau.py.
- Парсер добавлен в processor.py и экспортирован в __init__.py.

**Логика парсинга Alatau City Bank**
Документ этого банка имеет плотную структуру (13 колонок) с четко прорисованной табличной сеткой.

1. Стратегия извлечения

- Использованы жесткие настройки table_settings со стратегиями "vertical_strategy": "lines" и "horizontal_strategy": "lines".
- Это предотвращает "склеивание" пустых ячеек (например, когда транзакция прошла только по дебету, а кредит пустой), что критично для таблиц с большим количеством колонок. 
- snap_tolerance немного увеличен для лучшего распознавания линий.

2. Обработка данных
- Дата и время: В первой колонке время идет под датой через перенос строки (02.10.2025\n10:28). Реализовано отсечение времени с помощью регулярного выражения \d{2}\.\d{2}\.\d{4}.
 
- Очистка OCR: Добавлена пре-очистка сумм от случайных букв "О" вместо нулей перед передачей в базовый метод clean_amount.
 
- Формирование Payment:
          Назначение платежа (колонка 8) и Корреспондент (колонка 9) склеиваются в поле merchant.
          Отдельно заполняются correspondent и iin_bin.